### PR TITLE
mark-devkit: Bump virtual/rust-1.84.1

### DIFF
--- a/virtual/rust/rust-1.84.1.ebuild
+++ b/virtual/rust/rust-1.84.1.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for Rust language compiler"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="*"
+
+BDEPEND=""
+RDEPEND="|| ( ~dev-lang/rust-bin-1.84.1[${MULTILIB_USEDEP}] ~dev-lang/rust-1.84.1[${MULTILIB_USEDEP}] )"


### PR DESCRIPTION
Automatic bump of package virtual/rust-1.84.1 for branch mark-unstable by mark-bot