### PR TITLE
mark-devkit: Bump net-libs/deno-2.2.11-r1

### DIFF
--- a/net-libs/deno/deno-2.2.11-r1.ebuild
+++ b/net-libs/deno/deno-2.2.11-r1.ebuild
@@ -32,10 +32,12 @@ src_unpack() {
 src_compile() {
 	# Don't try to fetch prebuilt V8, build it instead
 	export V8_FROM_SOURCE=1
-	cargo_src_compile
+    cargo_src_compile
 }
 
 src_install() {
 	# Install the binary directly, cargo install doesn't work on workspaces
 	dobin target/release/deno
+
+	dodoc -r docs
 }


### PR DESCRIPTION
Automatic bump of package net-libs/deno-2.2.11-r1 for branch mark-iii by mark-bot