### PR TITLE
mark-devkit: Bump virtual/zig-0.14.1

### DIFF
--- a/virtual/zig/zig-0.14.1.ebuild
+++ b/virtual/zig/zig-0.14.1.ebuild
@@ -1,0 +1,13 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for Zig language compiler"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="*"
+
+
+BDEPEND=""
+RDEPEND="|| ( ~dev-lang/zig-bin-0.14.1 ~dev-lang/zig-0.14.1 )"


### PR DESCRIPTION
Automatic bump of package virtual/zig-0.14.1 for branch mark-xl by mark-bot