### PR TITLE
mark-devkit: Bump net-libs/nodejs-20.19.2

### DIFF
--- a/net-libs/nodejs/nodejs-20.19.2.ebuild
+++ b/net-libs/nodejs/nodejs-20.19.2.ebuild
@@ -1,0 +1,38 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+
+inherit python-any-r1
+
+DESCRIPTION="Node.js JavaScript runtime"
+HOMEPAGE="https://nodejs.org"
+SRC_URI="https://api.github.com/repos/nodejs/node/tarball/v20.19.2 -> nodejs-20.19.2.tar.gz"
+
+LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
+SLOT="0"
+KEYWORDS="*"
+IUSE=""
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+"
+
+post_src_unpack() {
+	mv "${WORKDIR}"/nodejs-node-* "${S}" || die
+}
+
+src_configure() {
+	configure_options=(
+		# By default, prefix is /usr/local, which is outside of PATH,
+		# set it to /usr instead:
+		--prefix="${EPREFIX}"/usr
+	)
+
+	# NOTE: `econf` default flags appear to trip up the configure process,
+	#       directly call the ./configure script instead.
+	./configure "${configure_options[@]}"
+}


### PR DESCRIPTION
Automatic bump of package net-libs/nodejs-20.19.2 for branch mark-31 by mark-bot