### PR TITLE
mark-devkit: [mark-xl] Bump virtual/zig-0.16.0

### DIFF
--- a/virtual/zig/zig-0.16.0.ebuild
+++ b/virtual/zig/zig-0.16.0.ebuild
@@ -1,0 +1,15 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Virtual for Zig language compiler"
+HOMEPAGE="https://ziglang.org/"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="|| ( ~dev-lang/zig-bin-0.16.0 ~dev-lang/zig-0.16.0 )
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/zig-0.16.0 for branch mark-xl by mark-bot