### PR TITLE
mark-devkit: [mark-xl] Bump virtual/rust-1.96.0

### DIFF
--- a/virtual/rust/rust-1.96.0.ebuild
+++ b/virtual/rust/rust-1.96.0.ebuild
@@ -1,0 +1,20 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Virtual for Rust language compiler"
+HOMEPAGE="https://www.rust-lang.org"
+LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="|| (
+	  ~dev-lang/rust-bin-1.96.0
+	  ~dev-lang/rust-1.96.0
+	)
+	
+"
+DEPEND="${RDEPEND}
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/rust-1.96.0 for branch mark-xl by mark-bot